### PR TITLE
Fix std::shared_timed_mutex issues on OS X

### DIFF
--- a/prometheus/collector.cc
+++ b/prometheus/collector.cc
@@ -2,9 +2,8 @@
 #include "metrics.hh"
 #include "registry.hh"
 #include "prometheus/proto/metrics.pb.h"
+#include "mutex.hh"
 
-#include <mutex>
-#include <shared_mutex>
 #include <list>
 
 namespace prometheus {
@@ -20,13 +19,13 @@ namespace prometheus {
     Collector::~Collector() {}
 
     void Collector::register_metric(AbstractMetric* metric) {
-      std::unique_lock<std::shared_timed_mutex> l(mutex_);
+      std::unique_lock<impl::shared_timed_mutex> l(mutex_);
       metrics_.push_back(metric);
     }
 
     std::list<MetricFamily*> Collector::collect() const {
       std::list<MetricFamily*> v;
-      std::shared_lock<std::shared_timed_mutex> l(mutex_);
+      impl::shared_lock<impl::shared_timed_mutex> l(mutex_);
       for (auto const m : metrics_) {
         auto* mf = new MetricFamily;
         m->collect(mf);

--- a/prometheus/collector.hh
+++ b/prometheus/collector.hh
@@ -2,8 +2,8 @@
 #define PROMETHEUS_COLLECTOR_HH_
 
 #include "proto/stubs.hh"
+#include "mutex.hh"
 
-#include <shared_mutex>
 #include <list>
 #include <stdexcept>
 #include <vector>
@@ -65,7 +65,7 @@ namespace prometheus {
       Collector& operator=(Collector const&) = delete;
 
       std::vector<AbstractMetric*> metrics_;
-      mutable std::shared_timed_mutex mutex_;
+      mutable impl::shared_timed_mutex mutex_;
     };
 
     extern Collector global_collector;

--- a/prometheus/mutex.hh
+++ b/prometheus/mutex.hh
@@ -1,0 +1,18 @@
+#ifndef PROMETHEUS_MUTEX_HH__
+# define PROMETHEUS_MUTEX_HH__
+
+# include <mutex>
+# include <shared_mutex>
+
+namespace prometheus { namespace impl {
+
+# ifdef __APPLE__
+  using shared_timed_mutex                = std::mutex;
+  template <typename T> using shared_lock = std::unique_lock<T>;
+# else
+  using shared_timed_mutex                = std::shared_timed_mutex;
+  template <typename T> using shared_lock = std::shared_lock<T>;
+# endif
+
+}} // end of namespace prometheus::impl
+#endif // PROMETHEUS_MUTEX_HH__

--- a/prometheus/registry.cc
+++ b/prometheus/registry.cc
@@ -2,10 +2,9 @@
 #include "client.hh"
 #include "exceptions.hh"
 #include "prometheus/proto/metrics.pb.h"
+#include "mutex.hh"
 
 #include <algorithm>
-#include <mutex>
-#include <shared_mutex>
 #include <vector>
 
 namespace prometheus {
@@ -20,7 +19,7 @@ namespace prometheus {
     CollectorRegistry::~CollectorRegistry() {}
 
     void CollectorRegistry::register_collector(ICollector* collector) {
-      std::unique_lock<std::shared_timed_mutex> l(mutex_);
+      std::unique_lock<impl::shared_timed_mutex> l(mutex_);
       if (std::find(collectors_.begin(), collectors_.end(), collector) !=
           collectors_.end()) {
         throw err::CollectorManagementException();
@@ -29,7 +28,7 @@ namespace prometheus {
     }
 
     void CollectorRegistry::unregister_collector(ICollector* collector) {
-      std::unique_lock<std::shared_timed_mutex> l(mutex_);
+      std::unique_lock<impl::shared_timed_mutex> l(mutex_);
       auto it = std::find(collectors_.begin(), collectors_.end(), collector);
       if (it == collectors_.end()) {
         throw err::CollectorManagementException();
@@ -38,7 +37,7 @@ namespace prometheus {
     }
 
     std::list<MetricFamily*> CollectorRegistry::collect() const {
-      std::shared_lock<std::shared_timed_mutex> l(mutex_);
+      impl::shared_lock<impl::shared_timed_mutex> l(mutex_);
       std::list<MetricFamily*> metrics;
       for (auto const& c : collectors_) {
 	try {

--- a/prometheus/registry.hh
+++ b/prometheus/registry.hh
@@ -3,9 +3,9 @@
 
 #include "collector.hh"
 #include "proto/stubs.hh"
+#include "mutex.hh"
 
 #include <ostream>
-#include <shared_mutex>
 #include <list>
 #include <vector>
 
@@ -39,7 +39,7 @@ namespace prometheus {
       CollectorRegistry(CollectorRegistry const&) = delete;
       CollectorRegistry operator=(CollectorRegistry const&) = delete;
 
-      mutable std::shared_timed_mutex mutex_;
+      mutable impl::shared_timed_mutex mutex_;
       std::vector<ICollector*> collectors_;
     };
 


### PR DESCRIPTION
Detect the availability of std::shared_timed_mutex at configure time. In case it is missing degrade to std::mutex and std::unique_lock gracefully.
