### PR TITLE
Add the tests to the CMake build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "external/gtest"]
+	path = external/gtest
+	url = git@github.com:google/googletest.git
+[submodule "external/fake_clock"]
+	path = external/fake_clock
+	url = git@github.com:korfuri/fake_clock.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ addons:
       ## For integrations
       - libmicrohttpd-dev
 
+# disable the default submodule logic
+git:
+  submodules: false
+
 # Eventually, Bazel will have binary packages and we'll be able to
 # just download a prebuilt distribution of Bazel. For now, build it
 # from source every time.
@@ -32,6 +36,8 @@ before_install:
   - chmod +x bazel-0.1.0-installer-linux-x86_64.sh
   - ./bazel-0.1.0-installer-linux-x86_64.sh --user
   - cat ~/.bazelrc >> .bazelrc
+  - sed -i 's/git@github.com:/git:\/\/github.com\//' .gitmodules
+  - git submodule update --init --recursive
 
 script:
   - bazel test //prometheus/...
@@ -40,6 +46,7 @@ script:
   - CC=gcc-4.9 CXX=g++-4.9 cmake ..
   - make -j3
   - prometheus/client_demo
+  - make test
   - popd
   - pushd integrations/gnu_libmicrohttpd
   - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,18 @@
 cmake_minimum_required (VERSION 2.8.12)
 
 project ("prometheus-client")
+enable_testing()
 
 set(PROMETHEUS_CLIENT_CXX_STANDARD --std=c++14)
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/gtest/CMakeLists.txt)
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external/gtest)
+  set(PROMETHEUS_HAS_LOCAL_GTEST true)
+  set(GTEST_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/external/gtest/googletest/include)
+  set(PROMETHEUS_FAKE_CLOCK_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/fake_clock)
+  add_library(fake_clock external/fake_clock/fake_clock.cc)
+  target_compile_options(fake_clock PRIVATE ${PROMETHEUS_CLIENT_CXX_STANDARD})
+endif()
 
 add_subdirectory(prometheus)
 add_subdirectory(integrations/gnu_libmicrohttpd)

--- a/README.md
+++ b/README.md
@@ -19,15 +19,28 @@ This project uses [Bazel](http://bazel.io) or CMake to build
   * `apt-get install libicu-dev` for Unicode support
   * `apt-get install libprotobuf-dev protobuf-compiler` for Protocol Buffers
 
-NOTE: Test execution in CMake has not been implemented.
+On Mac OS we test using dependencies from homebrew:
 
-## Requirements for tests when not using Bazel
+````bash
+$ brew install protobuf icu4c
+````
+
+## Testing with CMake
 
 The Bazel workspace will pull these automatically for you. If you're
 not using Bazel, you'll need:
 
   * [gtest](https://code.google.com/p/googletest/) is used in unit tests.
   * [fake_clock](https://github.com/korfuri/fake_clock) is used in unit tests.
+
+Both dependencies are linked as git submodules. To get the submodules run:
+
+````bash
+$ git submodule update --init
+````
+
+Now regenerate your build system using `cmake` and run the tests with 
+`make test` or what have you.
 
 # Usage
 

--- a/integrations/gnu_libmicrohttpd/prometheus_microhttpd.cc
+++ b/integrations/gnu_libmicrohttpd/prometheus_microhttpd.cc
@@ -16,7 +16,6 @@ void collect_as_text_format_to_ostream(std::ostream& os) {
   auto v = prometheus::impl::global_registry.collect();
   for (auto mf : v) {
     prometheus::metricfamily_proto_to_ostream(os, mf);
-    prometheus::delete_metricfamily(mf);
   }
 }
 

--- a/integrations/gnu_libmicrohttpd/prometheus_microhttpd.cc
+++ b/integrations/gnu_libmicrohttpd/prometheus_microhttpd.cc
@@ -12,17 +12,9 @@
 
 #define TEXT_FORMAT_CONTENT_TYPE "text/plain; version=0.0.4"
 
-void collect_as_text_format_to_ostream(std::ostream& os) {
-  auto v = prometheus::impl::global_registry.collect();
-  for (auto mf : v) {
-    prometheus::metricfamily_proto_to_ostream(os, mf);
-  }
-}
-
 std::string collect_as_text_format_to_string() {
-  std::ostringstream ss;
-  collect_as_text_format_to_ostream(ss);
-  return ss.str();
+  auto collection = prometheus::impl::global_registry.collect();
+  return prometheus::render(collection, prometheus::fmt_text);
 }
 
 MHD_Response* handle_metrics(struct MHD_Connection* connection) {

--- a/prometheus/CMakeLists.txt
+++ b/prometheus/CMakeLists.txt
@@ -14,7 +14,8 @@ endif()
 pkg_check_modules(ICU REQUIRED icu-io icu-i18n icu-uc)
 pkg_check_modules(PB REQUIRED protobuf)
 
-include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${ICU_INCLUDE_DIRS})
+include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_BINARY_DIR} ${ICU_INCLUDE_DIRS}
+                    ${GTEST_INCLUDE_DIRS})
 link_directories(${ICU_LIBRARY_DIRS})
 
 add_library(prometheus-client SHARED
@@ -39,6 +40,22 @@ target_compile_options(prometheus-client PRIVATE ${PROMETHEUS_CLIENT_CXX_STANDAR
 add_executable(client_demo client_demo_main.cc)
 target_link_libraries(client_demo prometheus-client)
 target_compile_options(client_demo PRIVATE ${PROMETHEUS_CLIENT_CXX_STANDARD})
+
+function(prometheus_test test_name)
+  add_executable(${test_name} ${test_name}.cc)
+  target_link_libraries(${test_name} prometheus-client
+                        gtest gtest_main fake_clock ${ICU_LIBRARIES})
+  target_compile_options(${test_name} PRIVATE ${PROMETHEUS_CLIENT_CXX_STANDARD})
+  add_test(${test_name} ${test_name})
+endfunction()
+
+if(PROMETHEUS_HAS_LOCAL_GTEST) 
+  include_directories(${PROMETHEUS_FAKE_CLOCK_DIR})
+  prometheus_test(client_test)
+  prometheus_test(client_concurrent_test)
+  #prometheus_test(benchmark_test)
+  prometheus_test(output_formatter)
+endif()
 
 set(PKG_CONFIG_LIBDIR "\${prefix}/lib")
 set(PKG_CONFIG_INCLUDEDIR "\${prefix}/include/")

--- a/prometheus/benchmark_test.cc
+++ b/prometheus/benchmark_test.cc
@@ -159,7 +159,6 @@ int main(int argc, char**argv) {
       if (m->name() == "test_runtime_last_s") {
         prometheus::metricfamily_proto_to_ostream(std::cout, m);
       }
-      prometheus::delete_metricfamily(m);
     }
   }
   return retval;

--- a/prometheus/client_demo_main.cc
+++ b/prometheus/client_demo_main.cc
@@ -52,7 +52,6 @@ int main() {
   for (auto m : v) {
     std::string s;
     std::cout << prometheus::metricfamily_proto_to_string(m);
-    prometheus::delete_metricfamily(m);
   }
   return 0;
 }

--- a/prometheus/collector.cc
+++ b/prometheus/collector.cc
@@ -23,7 +23,7 @@ namespace prometheus {
       metrics_.push_back(metric);
     }
 
-    Collector::collection_type Collector::collect() const {
+    collection_type Collector::collect() const {
       collection_type v;
       impl::shared_lock<impl::shared_timed_mutex> l(mutex_);
       for (auto const m : metrics_) {

--- a/prometheus/collector.cc
+++ b/prometheus/collector.cc
@@ -24,12 +24,12 @@ namespace prometheus {
     }
 
     Collector::collection_type Collector::collect() const {
-      std::list<MetricFamily*> v;
+      collection_type v;
       impl::shared_lock<impl::shared_timed_mutex> l(mutex_);
       for (auto const m : metrics_) {
         auto* mf = new MetricFamily;
         m->collect(mf);
-        v.push_back(mf);
+        v.push_back(MetricFamilyPtr(mf));
       }
       return v;
     }

--- a/prometheus/collector.cc
+++ b/prometheus/collector.cc
@@ -2,9 +2,8 @@
 #include "metrics.hh"
 #include "registry.hh"
 #include "prometheus/proto/metrics.pb.h"
+#include "mutex.hh"
 
-#include <mutex>
-#include <shared_mutex>
 #include <list>
 
 namespace prometheus {
@@ -20,13 +19,13 @@ namespace prometheus {
     Collector::~Collector() {}
 
     void Collector::register_metric(AbstractMetric* metric) {
-      std::unique_lock<std::shared_timed_mutex> l(mutex_);
+      std::unique_lock<impl::shared_timed_mutex> l(mutex_);
       metrics_.push_back(metric);
     }
 
     std::list<MetricFamily*> Collector::collect() const {
       std::list<MetricFamily*> v;
-      std::shared_lock<std::shared_timed_mutex> l(mutex_);
+      impl::shared_lock<impl::shared_timed_mutex> l(mutex_);
       for (auto const m : metrics_) {
         auto* mf = new MetricFamily;
         m->collect(mf);

--- a/prometheus/collector.cc
+++ b/prometheus/collector.cc
@@ -23,7 +23,7 @@ namespace prometheus {
       metrics_.push_back(metric);
     }
 
-    std::list<MetricFamily*> Collector::collect() const {
+    Collector::collection_type Collector::collect() const {
       std::list<MetricFamily*> v;
       impl::shared_lock<impl::shared_timed_mutex> l(mutex_);
       for (auto const m : metrics_) {

--- a/prometheus/collector.hh
+++ b/prometheus/collector.hh
@@ -1,7 +1,7 @@
 #ifndef PROMETHEUS_COLLECTOR_HH_
 #define PROMETHEUS_COLLECTOR_HH_
 
-#include "proto/stubs.hh"
+#include "family.hh"
 #include "mutex.hh"
 
 #include <list>
@@ -11,8 +11,6 @@
 namespace prometheus {
 
   namespace impl {
-    using ::prometheus::client::MetricFamily;
-
     class AbstractMetric;
     class CollectorRegistry;
   }
@@ -28,7 +26,7 @@ namespace prometheus {
    public:
     virtual ~ICollector() {}
 
-    typedef std::list<impl::MetricFamily*> collection_type;
+    typedef std::list<MetricFamilyPtr> collection_type;
 
     // Returns a list of MetricFamily protobufs ready to be
     // exported. The called gain ownership of all allocated

--- a/prometheus/collector.hh
+++ b/prometheus/collector.hh
@@ -26,8 +26,6 @@ namespace prometheus {
    public:
     virtual ~ICollector() {}
 
-    typedef std::list<MetricFamilyPtr> collection_type;
-
     // Returns a list of MetricFamily protobufs ready to be
     // exported. The called gain ownership of all allocated
     // MetricFamily objects. This method must be thread-safe. It may

--- a/prometheus/collector.hh
+++ b/prometheus/collector.hh
@@ -28,6 +28,8 @@ namespace prometheus {
    public:
     virtual ~ICollector() {}
 
+    typedef std::list<impl::MetricFamily*> collection_type;
+
     // Returns a list of MetricFamily protobufs ready to be
     // exported. The called gain ownership of all allocated
     // MetricFamily objects. This method must be thread-safe. It may
@@ -37,7 +39,7 @@ namespace prometheus {
     // happen. Other exceptions will interrupt the registry's
     // collection process and no metrics will be exposed for this
     // collection of the whole registry.
-    virtual std::list<impl::MetricFamily*> collect() const = 0;
+    virtual collection_type collect() const = 0;
   };
 
   class CollectionException : public std::runtime_error {};
@@ -54,7 +56,7 @@ namespace prometheus {
       virtual ~Collector();
 
       // See ICollector::collect.
-      virtual std::list<MetricFamily*> collect() const;
+      virtual collection_type collect() const;
 
       // Registers a metric with this Collector. The metric
       // can't be unregistered.

--- a/prometheus/collector.hh
+++ b/prometheus/collector.hh
@@ -2,8 +2,8 @@
 #define PROMETHEUS_COLLECTOR_HH_
 
 #include "proto/stubs.hh"
+#include "mutex.hh"
 
-#include <shared_mutex>
 #include <list>
 #include <stdexcept>
 #include <vector>
@@ -65,7 +65,7 @@ namespace prometheus {
       Collector& operator=(Collector const&) = delete;
 
       std::vector<AbstractMetric*> metrics_;
-      mutable std::shared_timed_mutex mutex_;
+      mutable impl::shared_timed_mutex mutex_;
     };
 
     extern Collector global_collector;

--- a/prometheus/family.hh
+++ b/prometheus/family.hh
@@ -1,0 +1,14 @@
+#ifndef PROMETHEUS_METRIC_FAMILY_HH__
+# define PROMETHEUS_METRIC_FAMILY_HH__
+
+#include <memory>
+
+#include "proto/stubs.hh"
+
+namespace prometheus {
+
+  using ::prometheus::client::MetricFamily;
+  using MetricFamilyPtr = std::shared_ptr<MetricFamily>;
+
+}; // end of namespace prometheus
+#endif // PROMETHEUS_METRIC_FAMILY_HH__

--- a/prometheus/family.hh
+++ b/prometheus/family.hh
@@ -2,6 +2,7 @@
 # define PROMETHEUS_METRIC_FAMILY_HH__
 
 #include <memory>
+#include <list>
 
 #include "proto/stubs.hh"
 
@@ -9,6 +10,7 @@ namespace prometheus {
 
   using ::prometheus::client::MetricFamily;
   using MetricFamilyPtr = std::shared_ptr<MetricFamily>;
+  using collection_type = std::list<MetricFamilyPtr>;
 
 }; // end of namespace prometheus
 #endif // PROMETHEUS_METRIC_FAMILY_HH__

--- a/prometheus/mutex.hh
+++ b/prometheus/mutex.hh
@@ -1,0 +1,18 @@
+#ifndef PROMETHEUS_MUTEX_HH__
+# define PROMETHEUS_MUTEX_HH__
+
+# include <mutex>
+# include <shared_mutex>
+
+namespace prometheus { namespace impl {
+
+# ifdef __APPLE__
+  using shared_timed_mutex                = std::mutex;
+  template <typename T> using shared_lock = std::unique_lock<T>;
+# else
+  using shared_timed_mutex                = std::shared_timed_mutex;
+  template <typename T> using shared_lock = std::shared_lock<T>;
+# endif
+
+}} // end of namespace prometheus::impl
+#endif // PROMETHEUS_MUTEX_HH__

--- a/prometheus/output_formatter.cc
+++ b/prometheus/output_formatter.cc
@@ -150,13 +150,13 @@ namespace prometheus {
     }
   }
 
-  std::string metricfamily_proto_to_string(MetricFamily const* mf) {
+  std::string metricfamily_proto_to_string(MetricFamilyPtr mf) {
     std::ostringstream ss;
     metricfamily_proto_to_ostream(ss, mf);
     return ss.str();
   }
 
-  void metricfamily_proto_to_ostream(std::ostream& os, MetricFamily const* mf) {
+  void metricfamily_proto_to_ostream(std::ostream& os, MetricFamilyPtr mf) {
     if (!mf->has_name() || !mf->has_type()) {
       throw impl::OutputFormatterException(
 	impl::OutputFormatterException::kMissingRequiredField);

--- a/prometheus/output_formatter.hh
+++ b/prometheus/output_formatter.hh
@@ -8,10 +8,35 @@
 
 namespace prometheus {
 
+  enum exposition_format {
+    fmt_text,
+    fmt_proto,             // protobuf delimited
+    //fmt_proto_txt        // not implemented
+    //fmt_proto_compact,   // not implemented
+  };
+
+  std::string
+  render(collection_type const& collection, exposition_format format);
+
+  void
+  render(collection_type const& collection, exposition_format format,
+      std::ostream & os);
+
+  std::string
+  collection_to_text(collection_type const& collection);
+
+  void
+  collection_to_text(collection_type const& collection, std::ostream & os);
+
+  std::string
+  collection_to_proto_delimited(collection_type const& collection);
+
+  void
+  collection_to_proto_delimited(collection_type const& collection, std::ostream & os);
+
   // Converts from the protobuf exposition format to the text
   // exposition format.
-  void metricfamily_proto_to_ostream(
-    std::ostream& os, MetricFamilyPtr mf);
+  void metricfamily_proto_to_ostream(std::ostream& os, MetricFamilyPtr mf);
   std::string metricfamily_proto_to_string(MetricFamilyPtr mf);
 
   // Escaping functions for each element of the text format.

--- a/prometheus/output_formatter.hh
+++ b/prometheus/output_formatter.hh
@@ -1,19 +1,18 @@
 #ifndef PROMETHEUS_OUTPUT_FORMATTER_HH__
 #define PROMETHEUS_OUTPUT_FORMATTER_HH__
 
-#include "prometheus/proto/metrics.pb.h"
-
 #include <string>
 
-namespace prometheus {
+#include "family.hh"
+#include "prometheus/proto/metrics.pb.h"
 
-  using ::prometheus::client::MetricFamily;
+namespace prometheus {
 
   // Converts from the protobuf exposition format to the text
   // exposition format.
   void metricfamily_proto_to_ostream(
-    std::ostream& os, MetricFamily const* mf);
-  std::string metricfamily_proto_to_string(MetricFamily const* mf);
+    std::ostream& os, MetricFamilyPtr mf);
+  std::string metricfamily_proto_to_string(MetricFamilyPtr mf);
 
   // Escaping functions for each element of the text format.
   std::string escape_double(double d);

--- a/prometheus/output_formatter_test.cc
+++ b/prometheus/output_formatter_test.cc
@@ -8,16 +8,18 @@ namespace {
   using namespace prometheus;
   using namespace prometheus::impl;
 
+  MetricFamilyPtr make_family() { return MetricFamilyPtr( new MetricFamily()); }
+
   class OutputFormatterTest : public ::testing::Test {};
 
   TEST_F(OutputFormatterTest, CounterTest) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
         "name: \"a\" help: \"b\" type: COUNTER metric: { counter: { value: 4.2 "
         "} }",
-        &mf));
+        &*mf));
     std::string s;
-    EXPECT_NO_THROW(s = metricfamily_proto_to_string(&mf));
+    EXPECT_NO_THROW(s = metricfamily_proto_to_string(mf));
     EXPECT_EQ(
         "# HELP a b\n"
         "# TYPE a counter\n"
@@ -26,12 +28,12 @@ namespace {
   }
 
   TEST_F(OutputFormatterTest, GaugeTest) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
         "name: \"a\" help: \"b\" type: GAUGE metric: { gauge: { value: 4.2 } }",
-        &mf));
+        &*mf));
     std::string s;
-    EXPECT_NO_THROW(s = metricfamily_proto_to_string(&mf));
+    EXPECT_NO_THROW(s = metricfamily_proto_to_string(mf));
     EXPECT_EQ(
         "# HELP a b\n"
         "# TYPE a gauge\n"
@@ -40,13 +42,13 @@ namespace {
   }
 
   TEST_F(OutputFormatterTest, UntypedTest) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
         "name: \"a\" help: \"b\" type: UNTYPED metric: { untyped: { value: 4.2 "
         "} }",
-        &mf));
+        &*mf));
     std::string s;
-    EXPECT_NO_THROW(s = metricfamily_proto_to_string(&mf));
+    EXPECT_NO_THROW(s = metricfamily_proto_to_string(mf));
     EXPECT_EQ(
         "# HELP a b\n"
         "# TYPE a untyped\n"
@@ -55,122 +57,122 @@ namespace {
   }
 
   TEST_F(OutputFormatterTest, HistogramTest) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
         "name: \"a\" help: \"b\" type: HISTOGRAM metric: { histogram: { bucket "
         "{ upper_bound: 4.2 cumulative_count: 2 } } }",
-        &mf));
+        &*mf));
     std::string s;
-    EXPECT_NO_THROW(s = metricfamily_proto_to_string(&mf));
+    EXPECT_NO_THROW(s = metricfamily_proto_to_string(mf));
   }
 
   TEST_F(OutputFormatterTest, EmptyMetricFamily) {
-    MetricFamily mf;
-    EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString("", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+    auto mf = make_family();
+    EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString("", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, NoMetric) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" type: COUNTER", &mf));
-    EXPECT_NO_THROW(metricfamily_proto_to_string(&mf));
+        "name: \"a\" help: \"b\" type: COUNTER", &*mf));
+    EXPECT_NO_THROW(metricfamily_proto_to_string(mf));
   }
 
   TEST_F(OutputFormatterTest, NoType) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" metric: {}", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        "name: \"a\" help: \"b\" metric: {}", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, CounterTypeNoCounterMetric) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" type: COUNTER metric: {}", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        "name: \"a\" help: \"b\" type: COUNTER metric: {}", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, GaugeTypeNoGaugeMetric) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" type: GAUGE metric: {}", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        "name: \"a\" help: \"b\" type: GAUGE metric: {}", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, SummaryTypeNoSummaryMetric) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" type: SUMMARY metric: {}", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        "name: \"a\" help: \"b\" type: SUMMARY metric: {}", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, UntypedTypeNoUntypedMetric) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" type: UNTYPED metric: {}", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        "name: \"a\" help: \"b\" type: UNTYPED metric: {}", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, HistogramTypeNoHistogramMetric) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" type: HISTOGRAM metric: {}", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        "name: \"a\" help: \"b\" type: HISTOGRAM metric: {}", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, CounterNoValue) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" type: COUNTER metric: { counter: {} }", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        "name: \"a\" help: \"b\" type: COUNTER metric: { counter: {} }", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, GaugeNoValue) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" type: GAUGE metric: { gauge: {} }", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        "name: \"a\" help: \"b\" type: GAUGE metric: { gauge: {} }", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, UntypedNoValue) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" type: UNTYPED metric: { untyped: {} }", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        "name: \"a\" help: \"b\" type: UNTYPED metric: { untyped: {} }", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, HistogramNoBuckets) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
         "name: \"a\" help: \"b\" type: HISTOGRAM metric: { histogram: {} }",
-        &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, SummaryNoQuantiles) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        "name: \"a\" help: \"b\" type: SUMMARY metric: { summary: {} }", &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        "name: \"a\" help: \"b\" type: SUMMARY metric: { summary: {} }", &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, HistogramBucketNoCount) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
         "name: \"a\" help: \"b\" type: HISTOGRAM metric: { histogram: { bucket "
         "{ upper_bound: 4.2 } } }",
-        &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, HistogramBucketNoUpperBound) {
-    MetricFamily mf;
+    auto mf = make_family();
     EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
         "name: \"a\" help: \"b\" type: HISTOGRAM metric: { histogram: { bucket "
         "{ cumulative_count: 2 } } }",
-        &mf));
-    EXPECT_THROW(metricfamily_proto_to_string(&mf), OutputFormatterException);
+        &*mf));
+    EXPECT_THROW(metricfamily_proto_to_string(mf), OutputFormatterException);
   }
 
   TEST_F(OutputFormatterTest, LabelValueEscaping) {

--- a/prometheus/registry.cc
+++ b/prometheus/registry.cc
@@ -52,7 +52,4 @@ namespace prometheus {
 
   } /* namespace impl */
 
-  void delete_metricfamily(::prometheus::client::MetricFamily* mf) {
-    delete mf;
-  }
 } /* namespace prometheus */

--- a/prometheus/registry.cc
+++ b/prometheus/registry.cc
@@ -2,10 +2,9 @@
 #include "client.hh"
 #include "exceptions.hh"
 #include "prometheus/proto/metrics.pb.h"
+#include "mutex.hh"
 
 #include <algorithm>
-#include <mutex>
-#include <shared_mutex>
 #include <vector>
 
 namespace prometheus {
@@ -20,7 +19,7 @@ namespace prometheus {
     CollectorRegistry::~CollectorRegistry() {}
 
     void CollectorRegistry::register_collector(ICollector* collector) {
-      std::unique_lock<std::shared_timed_mutex> l(mutex_);
+      std::unique_lock<impl::shared_timed_mutex> l(mutex_);
       if (std::find(collectors_.begin(), collectors_.end(), collector) !=
           collectors_.end()) {
         throw err::CollectorManagementException();
@@ -29,7 +28,7 @@ namespace prometheus {
     }
 
     void CollectorRegistry::unregister_collector(ICollector* collector) {
-      std::unique_lock<std::shared_timed_mutex> l(mutex_);
+      std::unique_lock<impl::shared_timed_mutex> l(mutex_);
       auto it = std::find(collectors_.begin(), collectors_.end(), collector);
       if (it == collectors_.end()) {
         throw err::CollectorManagementException();
@@ -38,7 +37,7 @@ namespace prometheus {
     }
 
     std::list<MetricFamily*> CollectorRegistry::collect() const {
-      std::shared_lock<std::shared_timed_mutex> l(mutex_);
+      impl::shared_lock<impl::shared_timed_mutex> l(mutex_);
       std::list<MetricFamily*> metrics;
       for (auto const& c : collectors_) {
 	try {

--- a/prometheus/registry.cc
+++ b/prometheus/registry.cc
@@ -36,12 +36,12 @@ namespace prometheus {
       collectors_.erase(it);
     }
 
-    std::list<MetricFamily*> CollectorRegistry::collect() const {
+    CollectorRegistry::collection_type CollectorRegistry::collect() const {
       impl::shared_lock<impl::shared_timed_mutex> l(mutex_);
-      std::list<MetricFamily*> metrics;
+      collection_type metrics;
       for (auto const& c : collectors_) {
 	try {
-	  std::list<MetricFamily*> collected_metrics = c->collect();
+	  collection_type collected_metrics = c->collect();
 	  metrics.splice(metrics.begin(), collected_metrics);
 	} catch (CollectionException const&) {
 	  collection_errors.inc();

--- a/prometheus/registry.cc
+++ b/prometheus/registry.cc
@@ -36,7 +36,7 @@ namespace prometheus {
       collectors_.erase(it);
     }
 
-    CollectorRegistry::collection_type CollectorRegistry::collect() const {
+    collection_type CollectorRegistry::collect() const {
       impl::shared_lock<impl::shared_timed_mutex> l(mutex_);
       collection_type metrics;
       for (auto const& c : collectors_) {

--- a/prometheus/registry.hh
+++ b/prometheus/registry.hh
@@ -12,8 +12,6 @@
 namespace prometheus {
   namespace impl {
 
-    using ::prometheus::client::MetricFamily;
-
     class CollectorRegistry {
       // A CollectorRegistry is the main interface through which
       // collection happens. A CollectorRegistry contains a list of
@@ -23,10 +21,12 @@ namespace prometheus {
       CollectorRegistry();
       ~CollectorRegistry();
 
+      using collection_type = Collector::collection_type;
+
       // Returns a list of MetricFamily protobufs ready to be
       // exported. The called gain ownership of all allocated
       // MetricFamily objects and must delete them to avoid leaks.
-      std::list<MetricFamily*> collect() const;
+      collection_type collect() const;
 
       // Register or unregister a collector. Registered collectors are
       // included in collections. Registering a collector twice, or

--- a/prometheus/registry.hh
+++ b/prometheus/registry.hh
@@ -3,9 +3,9 @@
 
 #include "collector.hh"
 #include "proto/stubs.hh"
+#include "mutex.hh"
 
 #include <ostream>
-#include <shared_mutex>
 #include <list>
 #include <vector>
 
@@ -39,7 +39,7 @@ namespace prometheus {
       CollectorRegistry(CollectorRegistry const&) = delete;
       CollectorRegistry operator=(CollectorRegistry const&) = delete;
 
-      mutable std::shared_timed_mutex mutex_;
+      mutable impl::shared_timed_mutex mutex_;
       std::vector<ICollector*> collectors_;
     };
 

--- a/prometheus/registry.hh
+++ b/prometheus/registry.hh
@@ -49,9 +49,6 @@ namespace prometheus {
 
   } /* namespace impl */
 
-  // Deletes a MetricFamily returned by a call to collect().
-  void delete_metricfamily(::prometheus::client::MetricFamily*);
-
 } /* namespace prometheus */
 
 #endif

--- a/prometheus/registry.hh
+++ b/prometheus/registry.hh
@@ -2,7 +2,7 @@
 #define PROMETHEUS_REGISTRY_HH__
 
 #include "collector.hh"
-#include "proto/stubs.hh"
+#include "family.hh"
 #include "mutex.hh"
 
 #include <ostream>
@@ -20,8 +20,6 @@ namespace prometheus {
      public:
       CollectorRegistry();
       ~CollectorRegistry();
-
-      using collection_type = Collector::collection_type;
 
       // Returns a list of MetricFamily protobufs ready to be
       // exported. The called gain ownership of all allocated

--- a/prometheus/standard_exports.cc
+++ b/prometheus/standard_exports.cc
@@ -96,7 +96,7 @@ namespace prometheus {
     private:
       // Convenience function to add a gauge to the list of
       // MetricFamilies and set its name/help/type and one value.
-      static void set_gauge(std::list<MetricFamily*>& l,
+      static void set_gauge(collection_type& l,
                             std::string const& name,
                             std::string const& help,
                             double value) {
@@ -105,7 +105,7 @@ namespace prometheus {
         mf->set_help(help);
         mf->set_type(::prometheus::client::MetricType::GAUGE);
         mf->add_metric()->mutable_gauge()->set_value(value);
-        l.push_back(mf);
+        l.push_back(MetricFamilyPtr(mf));
       }
 
       const double pagesize_;
@@ -122,8 +122,8 @@ namespace prometheus {
         global_registry.unregister_collector(this);
       }
 
-      std::list<MetricFamily*> collect() const {
-        std::list<MetricFamily*> l;
+      collection_type collect() const {
+        collection_type l;
         ProcSelfStatReader pss;
         ProcStatReader ps;
         ProcSelfFdReader psfd;


### PR DESCRIPTION
This adds the gtest and fake_clock repositories as git submodules. When present (that is the submodules are checked out) the CMake build picks them up and enables testing.

It also configures travis to fetch the submodules and run the tests.

```
$ make test
Running tests...
Test project /home/travis/build/korfuri/client_cpp/build
    Start 1: client_test
1/3 Test #1: client_test ......................   Passed    0.04 sec
    Start 2: client_concurrent_test
2/3 Test #2: client_concurrent_test ...........   Passed    0.31 sec
    Start 3: output_formatter
3/3 Test #3: output_formatter .................   Passed    0.01 sec
```
